### PR TITLE
feat: add key remapping through `keyd`

### DIFF
--- a/hosts/john-nix-05/configuration.nix
+++ b/hosts/john-nix-05/configuration.nix
@@ -16,6 +16,7 @@
     ../../modules/desktop/gnome.nix
     ../../modules/fonts.nix
     ../../modules/packages/default.nix
+    ../../modules/services/keyd.nix
     ../../modules/services/networking.nix
     ../../modules/services/printing.nix
     ../../modules/services/sound.nix

--- a/modules/services/keyd.nix
+++ b/modules/services/keyd.nix
@@ -1,0 +1,27 @@
+{ ... }:
+{
+  services.keyd = {
+    enable = true;
+    keyboards = {
+      default = {
+        ids = [ "*" ]; # Apply to all keyboards
+        settings = {
+          main = {
+            # Caps Lock: tap for Esc, hold for Ctrl (matches your evremap config)
+            capslock = "overload(control, esc)";
+
+            # Swap Alt and Meta keys (matches your evremap config)
+            leftalt = "leftmeta";
+            rightalt = "rightmeta";
+            leftmeta = "leftalt";
+          };
+        };
+        # Optional: Adjust timing for tap-hold behavior
+        extraConfig = ''
+          [main]
+          overload_tap_timeout = 200
+        '';
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds the following functionality:

- swaps `Alt` and `Meta` keys
- converts `CapsLock` to `Esc` and `Ctrl` (if held)