### PR TITLE
refactor: migrate CLI tools from Homebrew to nixpkgs

### DIFF
--- a/hosts/john-air-03/home.nix
+++ b/hosts/john-air-03/home.nix
@@ -7,15 +7,12 @@ in
     # Dotfiles configuration
     ../../modules/home/dotfiles.nix
 
-    # Config
-    ../../modules/home/bat.nix
-    ../../modules/home/bottom.nix
-    ../../modules/home/direnv.nix
-    ../../modules/home/git.nix
+    # Common terminal tools
+    ../../modules/home/common.nix
+
+    # Additional config
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
-    ../../modules/home/starship.nix
-    ../../modules/home/zoxide.nix
     ../../modules/home/zsh.nix
   ];
 

--- a/hosts/john-axl-06/home.nix
+++ b/hosts/john-axl-06/home.nix
@@ -7,15 +7,12 @@ in
     # Dotfiles configuration
     ../../modules/home/dotfiles.nix
 
-    # Config
-    ../../modules/home/bat.nix
-    ../../modules/home/bottom.nix
-    ../../modules/home/direnv.nix
-    ../../modules/home/git.nix
+    # Common terminal tools
+    ../../modules/home/common.nix
+
+    # Additional config
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
-    ../../modules/home/starship.nix
-    ../../modules/home/zoxide.nix
     ../../modules/home/zsh.nix
   ];
 

--- a/hosts/john-mbp-04/home.nix
+++ b/hosts/john-mbp-04/home.nix
@@ -11,15 +11,12 @@ in
     # Dotfiles configuration
     ../../modules/home/dotfiles.nix
 
-    # Config
-    ../../modules/home/bat.nix
-    ../../modules/home/bottom.nix
-    ../../modules/home/direnv.nix
-    ../../modules/home/git.nix
+    # Common terminal tools
+    ../../modules/home/common.nix
+
+    # Additional config
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
-    ../../modules/home/starship.nix
-    ../../modules/home/zoxide.nix
     ../../modules/home/zsh.nix
   ];
 

--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -10,7 +10,10 @@ in
     # Dotfiles configuration
     ../../modules/home/dotfiles.nix
 
-    # Packages
+    # Common terminal tools (shared across all hosts)
+    ../../modules/home/common.nix
+
+    # Additional packages
     ../../modules/packages/ai.nix
     ../../modules/packages/browsers.nix
     ../../modules/packages/developer.nix
@@ -20,19 +23,12 @@ in
     # Desktop
     ../../modules/desktop/hypr/default.nix
 
-    # Config
-    ../../modules/home/bat.nix
-    ../../modules/home/bottom.nix
-    ../../modules/home/direnv.nix
-    ../../modules/home/git.nix
+    # Host-specific config
     ../../modules/home/ghostty.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
     ../../modules/home/rclone.nix
-    ../../modules/home/starship.nix
     ../../modules/home/zed.nix
-    ../../modules/home/zellij.nix
-    ../../modules/home/zoxide.nix
     ../../modules/home/zsh.nix
   ];
 

--- a/modules/darwin/packages/common.nix
+++ b/modules/darwin/packages/common.nix
@@ -12,22 +12,6 @@
     ];
     # Always upgrade casks
     greedyCasks = true;
-    brews = [
-      "bat"
-      "bottom"
-      "fd"
-      "fzf"
-      "hyperfine"
-      "lazydocker"
-      "lazygit"
-      "nvtop"
-      "rename"
-      "ripgrep"
-      "starship"
-      "tree"
-      "zellij"
-      "zoxide"
-    ];
     global.autoUpdate = false;
     onActivation = {
       autoUpdate = true;

--- a/modules/home/common.nix
+++ b/modules/home/common.nix
@@ -1,0 +1,25 @@
+{ pkgs, ... }:
+{
+  imports = [
+    ./bat.nix
+    ./bottom.nix
+    ./direnv.nix
+    ./git.nix
+    ./starship.nix
+    ./zellij.nix
+    ./zoxide.nix
+  ];
+
+  # Terminal tools managed by nixpkgs (previously in Homebrew brews)
+  home.packages = with pkgs; [
+    fd
+    fzf
+    hyperfine
+    lazydocker
+    lazygit
+    ripgrep
+    tree
+    (if stdenv.isDarwin then nvtopPackages.apple else nvtopPackages.full)
+    rename
+  ];
+}

--- a/modules/home/zellij.nix
+++ b/modules/home/zellij.nix
@@ -1,3 +1,4 @@
+{ pkgs, ... }:
 {
   programs.zellij = {
     enable = true;
@@ -6,7 +7,7 @@
     settings = {
       theme = "tokyo-night-dark";
       pane_frames = true;
-      copy_command = "wl-copy";
+      copy_command = if pkgs.stdenv.isLinux then "wl-copy" else null;
       show_startup_tips = false;
       scroll_buffer_size = 100000;
     };

--- a/modules/packages/developer.nix
+++ b/modules/packages/developer.nix
@@ -1,30 +1,14 @@
 { pkgs, ... }:
 {
   home.packages = with pkgs; [
-    # Terminal and CLIs
+    # Terminal emulators and editors
     alacritty
-    bat
-    bottom
     bun
-    direnv
-    fd
     fnm
-    fzf
     ghostty
     gnumake
     helix
-    hyperfine
-    lazygit
-    nvtopPackages.intel
     parallel
-    rename
-    ripgrep
-    starship
-    tree
-    zellij
-    zoxide
-
-    # Editors
     vscode
     zed-editor
   ];


### PR DESCRIPTION
## Summary

Migrates common terminal tools from Homebrew brews to nixpkgs for all hosts. This provides consistency across Darwin and NixOS hosts and allows for version pinning via `flake.lock`.

## Changes

### New Module
- **`modules/home/common.nix`**: New Home Manager module for shared CLI tools across all hosts
  - Imports: bat, bottom, direnv, git, starship, zellij, zoxide (via `programs.*.enable`)
  - Packages: fd, fzf, hyperfine, lazydocker, lazygit, ripgrep, tree, rename
  - Platform-specific nvtop: `nvtopPackages.apple` for Darwin, `nvtopPackages.full` for Linux

### Modified Modules
- **`modules/darwin/packages/common.nix`**: Removed `brews` list (kept `casks` for GUI apps)
- **`modules/home/zellij.nix`**: Made platform-aware - only sets `copy_command = "wl-copy"` on Linux
- **`modules/packages/developer.nix`**: Cleaned up duplicated packages now in common.nix

### Host Updates
Updated all host `home.nix` files to import `modules/home/common.nix`:
- `hosts/john-air-03/home.nix`
- `hosts/john-axl-06/home.nix`
- `hosts/john-mbp-04/home.nix`
- `hosts/john-nix-05/home.nix`

## Rationale

1. **Single Source of Truth**: CLI tool versions are now pinned via `flake.lock` across all environments
2. **Declarative Consistency**: Same modules handle both installation and configuration
3. **Cross-Platform**: Darwin and NixOS hosts use identical tool configurations
4. **Reduced Maintenance**: One package list instead of separate Homebrew and Nix lists

## Testing

- [x] `nix flake check` passes
- [x] `nix build .#darwinConfigurations.john-axl-06.system --dry-run` succeeds and fetches packages from nixpkgs

## Notes

- GUI applications (casks) remain managed by Homebrew
- `nvtop` uses platform-specific variants (Apple Silicon support on Darwin)
- `zellij` configuration now handles clipboard differently per platform