### PR TITLE
feat: enable automatic time zone updates for NixOS

### DIFF
--- a/hosts/john-nix-05/configuration.nix
+++ b/hosts/john-nix-05/configuration.nix
@@ -18,6 +18,7 @@
     ../../modules/services/printing.nix
     ../../modules/services/sound.nix
     ../../modules/services/vpn.nix
+    ../../modules/services/location.nix
     ../../modules/gc/default.nix
   ];
 
@@ -40,7 +41,7 @@
   };
 
   # Set your time zone.
-  time.timeZone = "America/Toronto";
+  time.timeZone = null;
 
   # Select internationalisation properties.
   i18n.defaultLocale = "en_US.UTF-8";

--- a/modules/services/location.nix
+++ b/modules/services/location.nix
@@ -1,0 +1,5 @@
+{ ... }:
+{
+  services.geoclue2.enable = true;
+  services.automatic-timezoned.enable = true;
+}


### PR DESCRIPTION
## Summary
- Created `modules/services/location.nix` to enable `geoclue2` and `automatic-timezoned`.
- Updated `hosts/john-nix-05/configuration.nix` to import the new location module.
- Set `time.timeZone = null` on NixOS to allow the daemon to manage time zone updates dynamically.