### PR TITLE
feat: add standalone Home Manager config for heimdall VPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ sudo nix run nix-darwin -- switch --flake .#<hostname>
 
 # On NixOS
 sudo nixos-rebuild switch --flake .#<hostname>
+
+# On Linux with Home Manager (standalone, non-NixOS)
+nix run home-manager -- switch --flake .#<username>@<hostname>
 ```
 
 After the first successful rebuild, `just` will be installed and available for all subsequent commands.
@@ -46,6 +49,20 @@ To rebuild, run
 
 ```bash
 just dr <hostname>
+```
+
+## Home Manager (Standalone Linux)
+
+For standalone Home Manager on non-NixOS Linux systems (e.g., AlmaLinux, Ubuntu with Nix installed):
+
+```bash
+nix run home-manager -- switch --flake .#<username>@<hostname>
+```
+
+For example, to apply the configuration for `john@heimdall`:
+
+```bash
+nix run home-manager -- switch --flake .#john@heimdall
 ```
 
 ## Garbage Collection

--- a/flake.nix
+++ b/flake.nix
@@ -100,5 +100,13 @@
           username = "john";
         };
       };
+
+      homeConfigurations."john@heimdall" = home-manager.lib.homeManagerConfiguration {
+        pkgs = nixpkgs.legacyPackages.aarch64-linux;
+        modules = [ ./hosts/heimdall/home.nix ];
+        extraSpecialArgs = {
+          inherit inputs;
+        };
+      };
     };
 }

--- a/hosts/heimdall/home.nix
+++ b/hosts/heimdall/home.nix
@@ -1,0 +1,33 @@
+{
+  imports = [
+    # Dotfiles configuration
+    ../../modules/home/dotfiles.nix
+
+    # Common terminal tools (shared across all hosts)
+    # Includes: bottom, starship, direnv, bat, git, zoxide, zellij
+    # Packages: fd, fzf, hyperfine, lazygit, ripgrep, tree
+    ../../modules/home/common.nix
+
+    # Host-specific config
+    ../../modules/home/helix.nix
+    ../../modules/home/opencode.nix
+    ../../modules/home/zsh.nix
+  ];
+
+  home.username = "john";
+  home.homeDirectory = "/home/john";
+
+  home.stateVersion = "25.05";
+
+  # Aliases
+  home.shellAliases = {
+    lg = "lazygit";
+    cat = "bat";
+  };
+
+  # Enable XDG
+  xdg.enable = true;
+
+  # Let Home Manager install and manage itself.
+  programs.home-manager.enable = true;
+}

--- a/hosts/john-air-03/home.nix
+++ b/hosts/john-air-03/home.nix
@@ -9,6 +9,7 @@ in
 
     # Common terminal tools
     ../../modules/home/common.nix
+    ../../modules/home/workstation.nix
 
     # Additional config
     ../../modules/home/helix.nix

--- a/hosts/john-mbp-04/home.nix
+++ b/hosts/john-mbp-04/home.nix
@@ -13,6 +13,7 @@ in
 
     # Common terminal tools
     ../../modules/home/common.nix
+    ../../modules/home/workstation.nix
 
     # Additional config
     ../../modules/home/helix.nix

--- a/hosts/john-nix-05/home.nix
+++ b/hosts/john-nix-05/home.nix
@@ -12,6 +12,7 @@ in
 
     # Common terminal tools (shared across all hosts)
     ../../modules/home/common.nix
+    ../../modules/home/workstation.nix
 
     # Additional packages
     ../../modules/packages/ai.nix

--- a/modules/home/common.nix
+++ b/modules/home/common.nix
@@ -15,11 +15,9 @@
     fd
     fzf
     hyperfine
-    lazydocker
     lazygit
     ripgrep
     tree
-    (if stdenv.isDarwin then nvtopPackages.apple else nvtopPackages.intel)
     rename
   ];
 }

--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    lazydocker
+    (if stdenv.isDarwin then nvtopPackages.apple else nvtopPackages.intel)
+  ];
+}


### PR DESCRIPTION
## Summary
- Add standalone Home Manager configuration for the `heimdall` VPS (Hetzner CAX11, AlmaLinux 9, aarch64-linux)
- Create `hosts/heimdall/home.nix` with server-oriented QoL modules: `common.nix` (includes `bottom`/`btm` as system monitor), `zsh`, `starship`, `direnv`, `helix`, `opencode`
- Add `homeConfigurations."john@heimdall"` output to `flake.nix` using `home-manager.lib.homeManagerConfiguration` for standalone (non-NixOS) deployment
- Document Home Manager standalone usage in `README.md`
- **Refactor**: Extract workstation-specific packages (`nvtop`, `lazydocker`) from `common.nix` to new `modules/home/workstation.nix` module

## Details
- **Target**: User `john` on `heimdall` (aarch64-linux, AlmaLinux with Determinate Nix)
- **System monitor**: Uses `bottom` (`btm`) instead of `htop`/`btop`
- **Excluded**: All GUI/desktop modules (hyprland, waybar, browsers, ghostty), GPU monitoring tools, Docker tooling
- **Deployment**: 
  ```bash
  nix run home-manager -- switch --flake .#john@heimdall
  ```

## Architecture Changes
- **`modules/home/common.nix`**: Now contains only universal CLI tools (fd, fzf, ripgrep, lazygit, etc.)
- **`modules/home/workstation.nix`** (NEW): Contains workstation-specific packages (`nvtop`, `lazydocker`)
- **Personal machines** (`john-nix-05`, `john-air-03`, `john-mbp-04`): Import both `common.nix` and `workstation.nix` — zero functional change
- **Heimdall VPS**: Imports only `common.nix` — minimal, headless-appropriate package set

## Files Changed
- `flake.nix`: Add `homeConfigurations."john@heimdall"` output
- `hosts/heimdall/home.nix`: New Home Manager configuration for VPS
- `modules/home/workstation.nix`: New module for workstation-specific packages
- `modules/home/common.nix`: Remove `nvtop` and `lazydocker`
- `hosts/john-nix-05/home.nix`, `hosts/john-air-03/home.nix`, `hosts/john-mbp-04/home.nix`: Import `workstation.nix`
- `README.md`: Add Home Manager standalone documentation

Closes #33