### PR TITLE
feat(heimdall): add opencode package

### DIFF
--- a/hosts/heimdall/home.nix
+++ b/hosts/heimdall/home.nix
@@ -8,6 +8,9 @@
     # Packages: fd, fzf, hyperfine, lazygit, ripgrep, tree
     ../../modules/home/common.nix
 
+    # AI/development packages
+    ../../modules/packages/ai.nix
+
     # Host-specific config
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix


### PR DESCRIPTION
## Summary
Add opencode AI CLI tool to the heimdall VPS configuration.

## Context
heimdall is the dedicated host for the openclaw bot. Including opencode for the human user (john) provides:
- Consistent AI-assisted development environment across all hosts
- Ability to debug and interact with the openclaw bot using the same tooling
- No additional security overhead (heimdall already hosts sensitive credentials for openclaw)

## Changes
- Import `../../modules/packages/ai.nix` in `hosts/heimdall/home.nix`
- The `opencode.nix` home module is already present and manages the `.config/opencode` directory

## Post-Deployment
After applying this configuration, run:
```bash
opencode auth
```