### PR TITLE
fix(heimdall): disable zellij auto-start for SSH server

### DIFF
--- a/hosts/heimdall/home.nix
+++ b/hosts/heimdall/home.nix
@@ -17,6 +17,9 @@
     ../../modules/home/zsh.nix
   ];
 
+  # Server-specific: disable zellij auto-start to prevent nested sessions when SSH'd from workstation
+  custom.zellij.enableAutoStart = false;
+
   home.username = "john";
   home.homeDirectory = "/home/john";
 

--- a/modules/home/zellij.nix
+++ b/modules/home/zellij.nix
@@ -1,15 +1,25 @@
-{ pkgs, ... }:
+{ pkgs, lib, config, ... }:
 {
-  programs.zellij = {
-    enable = true;
-    enableZshIntegration = true;
+  options.custom.zellij = {
+    enableAutoStart = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable zellij auto-start in zsh (disable for SSH servers)";
+    };
+  };
 
-    settings = {
-      theme = "tokyo-night-dark";
-      pane_frames = true;
-      copy_command = if pkgs.stdenv.isLinux then "wl-copy" else "pbcopy";
-      show_startup_tips = false;
-      scroll_buffer_size = 100000;
+  config = {
+    programs.zellij = {
+      enable = true;
+      enableZshIntegration = config.custom.zellij.enableAutoStart;
+
+      settings = {
+        theme = "tokyo-night-dark";
+        pane_frames = true;
+        copy_command = if pkgs.stdenv.isLinux then "wl-copy" else "pbcopy";
+        show_startup_tips = false;
+        scroll_buffer_size = 100000;
+      };
     };
   };
 }


### PR DESCRIPTION
- Add configurable enableAutoStart option to zellij module
- Disable auto-start on heimdall to prevent nested sessions
- Prevents zellij from launching when SSH'd from workstation
- Resolves starship font rendering issues caused by nested zellij

Fixes nested zellij sessions and garbled prompt when connecting via: workstation → ghostty → zellij → ssh → heimdall

Workstation behavior unchanged (auto-start remains enabled by default).