### PR TITLE
fix(heimdall): add declarative ghostty terminfo via home-manager

### DIFF
--- a/hosts/heimdall/home.nix
+++ b/hosts/heimdall/home.nix
@@ -1,3 +1,4 @@
+{ pkgs, ... }:
 {
   imports = [
     # Dotfiles configuration
@@ -19,6 +20,13 @@
 
   # Server-specific: disable zellij auto-start to prevent nested sessions when SSH'd from workstation
   custom.zellij.enableAutoStart = false;
+
+  # Ghostty terminfo: system ncurses 6.4 compiles a corrupted entry;
+  # use the Nix-built terminfo (ncurses 6.6) to ensure correct terminal capabilities
+  home.file.".terminfo" = {
+    source = "${pkgs.ghostty.terminfo}/share/terminfo";
+    recursive = true;
+  };
 
   home.username = "john";
   home.homeDirectory = "/home/john";


### PR DESCRIPTION
System ncurses 6.4 on AlmaLinux 10 compiles a corrupted xterm-ghostty terminfo entry. Use pkgs.ghostty.terminfo (built with ncurses 6.6) to provide a correct entry in ~/.terminfo, shadowing the corrupted system copy.