### PR TITLE
docs: add terminfo troubleshooting guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,9 @@ This runs `nix flake check` to verify the configuration is valid.
 
 `rclone` is used to sync cloud storage to local drives. The configuration is pretty much ready to go, except you need to sign in to get access tokens to OneDrive and Google Drive.
 Refer to [docs/cloud-storage.md](./docs/cloud-storage.md) for more info.
+
+## Troubleshooting
+
+### Ghostty Terminfo Issues
+
+If you experience garbled terminal output or repeated characters when SSH'ing into servers, see [docs/terminfo-troubleshooting.md](./docs/terminfo-troubleshooting.md) for diagnosis and solutions.

--- a/docs/terminfo-troubleshooting.md
+++ b/docs/terminfo-troubleshooting.md
@@ -1,0 +1,115 @@
+# Terminfo Troubleshooting
+
+## Background
+
+Terminal emulators use terminfo databases to advertise their capabilities to applications. Ghostty uses the `xterm-ghostty` terminfo entry, which is included in ncurses 6.5-20241228 and later.
+
+## Problem: Corrupted Terminfo on Older Systems
+
+On systems with older ncurses versions (< 6.5), the `xterm-ghostty` terminfo entry may be compiled incorrectly, leading to:
+
+- Garbled terminal output
+- Repeated characters in prompts (especially with Starship)
+- Incorrect rendering of special characters and escape sequences
+
+### Root Cause
+
+Ghostty's `shell-integration-features = ssh-terminfo` automatically copies the terminfo entry to remote servers on first SSH connection. However, if the remote system has an older `tic` (terminfo compiler), it may produce a corrupted binary entry.
+
+**Example corruption:**
+```bash
+# Corrupted (ncurses 6.4):
+initc=...\E\,invis=\E[8m,
+
+# Correct (ncurses 6.6+):
+initc=...\E\\,
+invis=\E[8m,
+```
+
+The `initc` and `invis` capabilities get fused together, causing malformed escape sequences.
+
+## Solution: Declarative Terminfo via Home-Manager
+
+For servers managed by home-manager (e.g., `heimdall`), the terminfo is provided declaratively from the Nix store, which uses ncurses 6.6+.
+
+### Implementation
+
+In the host's `home.nix`:
+
+```nix
+{ pkgs, ... }:
+{
+  # Ghostty terminfo: system ncurses may compile a corrupted entry;
+  # use the Nix-built terminfo (ncurses 6.6+) to ensure correct terminal capabilities
+  home.file.".terminfo" = {
+    source = "${pkgs.ghostty.terminfo}/share/terminfo";
+    recursive = true;
+  };
+}
+```
+
+This places a correctly-compiled terminfo in `~/.terminfo/`, which takes precedence over the system-wide `/usr/share/terminfo/`.
+
+### Verification
+
+After applying the configuration:
+
+```bash
+# Check TERM value
+echo $TERM
+# Should output: xterm-ghostty
+
+# Verify terminfo is correct
+infocmp -x xterm-ghostty | grep initc
+# Should end with: \E\\,
+# NOT: \E\,invis=...
+
+# Check that terminfo is Nix-managed
+ls -la ~/.terminfo/x/xterm-ghostty
+# Should be a symlink to /nix/store/.../ghostty-*-terminfo/...
+
+# Test terminal rendering
+# Starship prompt should render cleanly without character repeats
+```
+
+## Manual Fix (Non-Home-Manager Systems)
+
+If you cannot use home-manager, manually install the correct terminfo from a system with ncurses 6.5+:
+
+```bash
+# From a workstation with Ghostty installed:
+infocmp -x xterm-ghostty | ssh user@remote-host -- tic -x -o ~/.terminfo -
+```
+
+**Note:** This requires the workstation's `infocmp` to output a correct terminfo source. On macOS versions before Sonoma, you may need to install ncurses via Homebrew:
+
+```bash
+brew install ncurses
+/opt/homebrew/opt/ncurses/bin/infocmp -x xterm-ghostty | ssh user@remote-host -- tic -x -o ~/.terminfo -
+```
+
+## Fallback: Use xterm-256color
+
+If the terminfo cannot be fixed, configure SSH to fall back to a compatible TERM value:
+
+```ssh-config
+# ~/.ssh/config
+Host problematic-server
+  SetEnv TERM=xterm-256color
+```
+
+Or in Ghostty's configuration:
+
+```
+shell-integration-features = ssh-env
+```
+
+**Trade-off:** This disables Ghostty-specific features (styled underlines, etc.) but ensures compatibility.
+
+## References
+
+- [Ghostty Terminfo Documentation](https://ghostty.org/docs/help/terminfo)
+- [ncurses 6.5 Release Notes](https://invisible-island.net/ncurses/announce.html#h2-overview)
+- Related PRs:
+  - [#37: Add declarative ghostty terminfo via home-manager](https://github.com/john-s-lin/infra/pull/37)
+  - [#36: Disable zellij auto-start for SSH server](https://github.com/john-s-lin/infra/pull/36)


### PR DESCRIPTION
## Summary
- Documents Ghostty terminfo corruption issue on systems with ncurses < 6.5
- Explains the declarative home-manager solution implemented in #37
- Provides manual fix instructions for non-Nix systems
- Adds troubleshooting section to README

## Context
After resolving the terminfo issues on heimdall (#37), this documents the root cause, solution, and verification steps for future reference.

## Changes
- **New:** `docs/terminfo-troubleshooting.md` - comprehensive troubleshooting guide
- **Modified:** `README.md` - added troubleshooting section linking to the guide

## Verification
- [x] Documentation is clear and actionable
- [x] Links to related PRs included
- [x] Manual fix instructions tested (Phase 1)
- [x] Declarative solution verified (Phase 2)