### PR TITLE
chore(darwin): remove docker-desktop from common packages

### DIFF
--- a/modules/darwin/packages/common.nix
+++ b/modules/darwin/packages/common.nix
@@ -2,7 +2,6 @@
   homebrew = {
     enable = true;
     casks = [
-      "docker-desktop"
       "ghostty"
       "google-chrome"
       "obsidian"


### PR DESCRIPTION
## Summary
- Removes Docker Desktop as a global dependency from macOS machines
- Containers will now be installed on a per-repo basis as needed

## Rationale
With the shift toward Nix for environment management, Docker Desktop is no longer necessary as a global tool. Individual projects that require container runtimes can manage their own dependencies via `shell.nix` or Flake inputs.