### PR TITLE
Add jujutsu (jj) VCS support to all hosts

### DIFF
--- a/modules/home/common.nix
+++ b/modules/home/common.nix
@@ -5,6 +5,7 @@
     ./bottom.nix
     ./direnv.nix
     ./git.nix
+    ./jujutsu.nix
     ./starship.nix
     ./zellij.nix
     ./zoxide.nix

--- a/modules/home/jujutsu.nix
+++ b/modules/home/jujutsu.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ ... }:
 {
   programs.jujutsu = {
     enable = true;

--- a/modules/home/jujutsu.nix
+++ b/modules/home/jujutsu.nix
@@ -2,10 +2,5 @@
 {
   programs.jujutsu = {
     enable = true;
-
-    settings = {
-      # Enable color output
-      ui.color = "auto";
-    };
   };
 }

--- a/modules/home/jujutsu.nix
+++ b/modules/home/jujutsu.nix
@@ -4,12 +4,6 @@
     enable = true;
 
     settings = {
-      # Git interoperability settings
-      git = {
-        # Automatically create local bookmarks for Git branches
-        auto-local-bookmark = true;
-      };
-
       # Enable color output
       ui.color = "auto";
     };

--- a/modules/home/jujutsu.nix
+++ b/modules/home/jujutsu.nix
@@ -4,9 +4,6 @@
     enable = true;
 
     settings = {
-      # Use Helix as the default editor
-      ui.editor = "hx";
-
       # Git interoperability settings
       git = {
         # Automatically create local bookmarks for Git branches

--- a/modules/home/jujutsu.nix
+++ b/modules/home/jujutsu.nix
@@ -4,9 +4,6 @@
     enable = true;
 
     settings = {
-      # Import local identity file (not tracked in repo)
-      import = [ "~/.config/jj/identity.toml" ];
-
       # Use Helix as the default editor
       ui.editor = "hx";
 

--- a/modules/home/jujutsu.nix
+++ b/modules/home/jujutsu.nix
@@ -1,0 +1,23 @@
+{ config, ... }:
+{
+  programs.jujutsu = {
+    enable = true;
+
+    settings = {
+      # Import local identity file (not tracked in repo)
+      import = [ "~/.config/jj/identity.toml" ];
+
+      # Use Helix as the default editor
+      ui.editor = "hx";
+
+      # Git interoperability settings
+      git = {
+        # Automatically create local bookmarks for Git branches
+        auto-local-bookmark = true;
+      };
+
+      # Enable color output
+      ui.color = "auto";
+    };
+  };
+}

--- a/modules/home/starship.nix
+++ b/modules/home/starship.nix
@@ -3,7 +3,7 @@
   programs.starship = {
     enable = true;
     settings = {
-      format = "$directory$python$rust$zig$git_branch$git_commit$git_state$git_status$cmd_duration$character";
+      format = "$directory$python$rust$zig$git_branch$git_commit$git_state$git_status$jj$cmd_duration$character";
       add_newline = false;
 
       directory = {
@@ -40,6 +40,11 @@
       };
 
       git_status = {
+        style = "bold purple";
+      };
+
+      jj = {
+        format = "[\\[$change_id$status\\]](\$style) ";
         style = "bold purple";
       };
     };


### PR DESCRIPTION
## Summary

- Add jujutsu VCS to all hosts via Home Manager
- Add jj module to Starship prompt

## Changes

- **modules/home/jujutsu.nix** (new): Minimal jj config (`enable = true`)
- **modules/home/common.nix**: Import jujutsu module
- **modules/home/starship.nix**: Add `$jj` to prompt format

## Design Decisions

- **Minimal config**: Kept to just `enable = true` since all settings (editor, color, git.auto-local-bookmark) are defaults in jj
- **No identity config**: Identity falls back to Git config when in Git repos
- **No aliases**: Intentionally omitted to encourage learning native jj commands

## References

Closes #42