### PR TITLE
feat: add gnome-keyring auto-unlock for Hyprland sessions

### DIFF
--- a/modules/desktop/gnome.nix
+++ b/modules/desktop/gnome.nix
@@ -15,6 +15,12 @@
     };
   };
 
+  # Unlock GNOME Keyring automatically at login via PAM
+  security.pam.services = {
+    gdm.enableGnomeKeyring = true;
+    login.enableGnomeKeyring = true;
+  };
+
   # Disable default GNOME apps
   environment.gnome.excludePackages = with pkgs; [
     baobab # disk usage analyzer

--- a/modules/desktop/hypr/default.nix
+++ b/modules/desktop/hypr/default.nix
@@ -62,6 +62,7 @@ in
       ];
 
       exec-once = [
+        "gnome-keyring-daemon --start --components=secrets"
         terminal
         "waybar"
         "hyprpaper"


### PR DESCRIPTION
## Summary

- Add `security.pam.services.gdm.enableGnomeKeyring` and `security.pam.services.login.enableGnomeKeyring` to `modules/desktop/gnome.nix` so GDM passes the login password to `gnome-keyring-daemon` via PAM, unlocking the keyring transparently at login for both GNOME and Hyprland sessions
- Add `gnome-keyring-daemon --start --components=secrets` to Hyprland's `exec-once` in `modules/desktop/hypr/default.nix` so the secrets daemon is guaranteed to be running in the Hyprland session (GNOME handles this automatically via its session manager; Hyprland does not)

## Problem

Apps like Zed, Chrome, and Thunderbird intermittently prompt for the "login keyring" password when opened under a Hyprland session. The keyring daemon was enabled (`services.gnome.gnome-keyring.enable = true`) but had no PAM integration to auto-unlock it at login, and no explicit startup in the Hyprland session.

## Notes

- `--components=secrets` only — SSH component excluded to avoid conflicting with the existing ssh-agent setup
- `--start` is idempotent; safe if the daemon is already running via D-Bus activation
- No changes to GNOME session behaviour — PAM integration is additive