### PR TITLE
feat: gmailctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ This runs `nix flake check` to verify the configuration is valid.
 `rclone` is used to sync cloud storage to local drives. The configuration is pretty much ready to go, except you need to sign in to get access tokens to OneDrive and Google Drive.
 Refer to [docs/cloud-storage.md](./docs/cloud-storage.md) for more info.
 
+### gmailctl
+
+`gmailctl` is installed declaratively, but its `~/.gmailctl/config.jsonnet` filter config is sourced from Bitwarden Secrets Manager.
+Refer to [docs/gmailctl.md](./docs/gmailctl.md) for setup and operational details.
+
 ## Troubleshooting
 
 ### Ghostty Terminfo Issues

--- a/docs/gmailctl.md
+++ b/docs/gmailctl.md
@@ -1,0 +1,47 @@
+# gmailctl
+
+`gmailctl` uses `~/.gmailctl` as its default config directory. This repo installs the `gmailctl` package, but does not manage `~/.gmailctl/config.jsonnet`.
+
+The filter configuration is stored in Bitwarden Secrets Manager and must be materialized locally on each workstation.
+
+## First-Time Setup
+
+After applying the host configuration on a personal workstation:
+
+1. Retrieve `config.jsonnet` from Bitwarden Secrets Manager.
+2. Write it to `~/.gmailctl/config.jsonnet`.
+3. Initialize Gmail access:
+
+```bash
+gmailctl init
+```
+
+This does not require the `gcloud` CLI. The setup flow uses Google's web-based OAuth flow and writes local auth state under `~/.gmailctl/`.
+
+## Managed vs Local Files
+
+- Repo-managed: `gmailctl` package installation only
+- Bitwarden-managed: `~/.gmailctl/config.jsonnet`
+- Local-only: OAuth credentials, tokens, and any other files created by `gmailctl init`
+
+Do not commit `config.jsonnet` or generated auth files into this repository.
+
+## Usage
+
+Preview differences before applying changes:
+
+```bash
+gmailctl diff
+```
+
+Apply the current declarative filter config:
+
+```bash
+gmailctl apply
+```
+
+## Upstream Notes
+
+- Default config location: `~/.gmailctl/config.jsonnet`
+- `--config` exists as an override for alternate config directories
+- Upstream discussion about migrating to XDG paths exists, but the default location remains `~/.gmailctl`

--- a/hosts/john-mba-03/home.nix
+++ b/hosts/john-mba-03/home.nix
@@ -16,6 +16,7 @@
     # Additional config
     ../../modules/home/bash.nix
     ../../modules/home/ghostty.nix
+    ../../modules/home/gmailctl.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
     ../../modules/home/zed.nix

--- a/hosts/john-mbp-04/home.nix
+++ b/hosts/john-mbp-04/home.nix
@@ -16,6 +16,7 @@
     # Additional config
     ../../modules/home/bash.nix
     ../../modules/home/ghostty.nix
+    ../../modules/home/gmailctl.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
     ../../modules/home/zed.nix

--- a/hosts/john-tpd-05/home.nix
+++ b/hosts/john-tpd-05/home.nix
@@ -29,6 +29,7 @@
     # Host-specific config
     ../../modules/home/alacritty.nix
     ../../modules/home/ghostty.nix
+    ../../modules/home/gmailctl.nix
     ../../modules/home/helix.nix
     ../../modules/home/opencode.nix
     ../../modules/home/rclone.nix

--- a/modules/home/gmailctl.nix
+++ b/modules/home/gmailctl.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    gmailctl
+  ];
+}


### PR DESCRIPTION
## Summary
- install `gmailctl` declaratively on personal workstations via Home Manager
- document the default `~/.gmailctl` workflow and clarify that `config.jsonnet` will be sourced from Bitwarden, not this repo
- keep gmailctl package-only for now so OAuth state and secret material remain local/unmanaged

Resolves #76

Follow-up: open a separate issue to wire up Bitwarden Secrets Manager retrieval for `~/.gmailctl/config.jsonnet`.